### PR TITLE
Add mark_bulk() method to rebuild the RBTree in one operation

### DIFF
--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.11)
 
 project(Lib-SWOC CXX)
-set(LIBSWOC_VERSION "1.5.14")
+set(LIBSWOC_VERSION "1.5.13")
 set(CMAKE_CXX_STANDARD 17)
 cmake_policy(SET CMP0087 NEW)
 # override "lib64" to be "lib" unless the user explicitly sets it.

--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -65,6 +65,11 @@ if (CMAKE_COMPILER_IS_GNUCXX)
     target_compile_options(libswoc PRIVATE -fPIC -Wall -Wextra -Werror -Wnon-virtual-dtor -Wpedantic -Wshadow)
 endif()
 
+# if BUILD_TESTING, then add a cpp defines for BUILD_TESTING
+if (BUILD_TESTING)
+    target_compile_definitions(libswoc PRIVATE BUILD_TESTING)
+endif()
+
 add_library(libswoc-static STATIC ${CC_FILES})
 set_target_properties(libswoc-static PROPERTIES OUTPUT_NAME swoc-static-${LIBSWOC_VERSION})
 if (CMAKE_COMPILER_IS_GNUCXX)
@@ -137,6 +142,6 @@ endif()
 # AFAICT the file isn't created at all even with this enabled.
 #export(TARGETS libswoc FILE libswoc-config.cmake)
 
-set(CLANG_DIRS )
+set(CLANG_DIRS)
 
 set_target_properties(libswoc-static PROPERTIES CLANG_FORMAT_DIRS "${PROJECT_SOURCE_DIR}/src;${PROJECT_SOURCE_DIR}/include")

--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.11)
 
 project(Lib-SWOC CXX)
-set(LIBSWOC_VERSION "1.5.13")
+set(LIBSWOC_VERSION "1.5.14")
 set(CMAKE_CXX_STANDARD 17)
 cmake_policy(SET CMP0087 NEW)
 # override "lib64" to be "lib" unless the user explicitly sets it.
@@ -138,7 +138,7 @@ if (LIBSWOC_INSTALL)
     )
 endif()
 
-# Alledgedly this makes the targets "importable from the build directory" but I see no evidence of that.
+# Allegedly this makes the targets "importable from the build directory" but I see no evidence of that.
 # AFAICT the file isn't created at all even with this enabled.
 #export(TARGETS libswoc FILE libswoc-config.cmake)
 

--- a/code/include/swoc/DiscreteRange.h
+++ b/code/include/swoc/DiscreteRange.h
@@ -1350,7 +1350,7 @@ DiscreteSpace<METRIC, PAYLOAD>::mark_bulk(std::pair<range_type, PAYLOAD>* start,
   // Timer [tree]: 0.0280254 seconds
   // Rebuild the entire red-black tree.
   detail::RBNode* temp_head = _list.head();
-  _root = static_cast<Node *>(swoc::detail::RBNode::buildTree(temp_head, _list.count()));
+  _root = static_cast<Node *>(detail::RBNode::buildTree(temp_head, _list.count()));
 }
 
 template <typename METRIC, typename PAYLOAD>

--- a/code/include/swoc/DiscreteRange.h
+++ b/code/include/swoc/DiscreteRange.h
@@ -757,9 +757,9 @@ protected:
     }
 
     self_type &
-    assign_min(METRIC const &m, bool updateTree = true) {
+    assign_min(METRIC const &m, bool update_tree = true) {
       _range.assign_min(m);
-      if (updateTree)
+      if (update_tree)
       {
         this->ripple_structure_fixup();
       }
@@ -767,9 +767,9 @@ protected:
     }
 
     self_type &
-    assign_max(METRIC const &m, bool updateTree = true) {
+    assign_max(METRIC const &m, bool update_tree = true) {
       _range.assign_max(m);
-      if (updateTree)
+      if (update_tree)
       {
         this->ripple_structure_fixup();
       }
@@ -835,19 +835,31 @@ public:
 
   ~DiscreteSpace();
 
-  void mark_bulk(std::vector<std::pair<range_type, PAYLOAD>> const &marks);
+  /** Mark ranges in one operation.
+   * 
+   * @param marks Vector of ranges and payloads to mark.
+   * @return @a this
+   */
+  self_type &mark_bulk(std::vector<std::pair<range_type, PAYLOAD>> const &marks);
 
-  void mark_bulk(std::pair<range_type, PAYLOAD>* start, size_t n);
+  /** Mark ranges in one operation.
+   * 
+   * @param start Pointer to the first range/payload pair.
+   * @param n Number of pairs.
+   * @return @a this
+   */
+  self_type &mark_bulk(std::pair<range_type, PAYLOAD>* start, size_t n);
 
   /** Set the @a payload for a @a range
    *
    * @param range Range to mark.
    * @param payload Payload to set.
+   * @param update_tree @c true to update the RBTree structure.
    * @return @a this
    *
    * Values in @a range are set to @a payload regardless of the current state.
    */
-  self_type &mark(range_type const &range, PAYLOAD const &payload, bool updateTree = true);
+  self_type &mark(range_type const &range, PAYLOAD const &payload, bool update_tree = true);
 
   /** Erase a @a range.
    *
@@ -983,37 +995,42 @@ protected:
    *
    * @param spot Target node.
    * @param node Node to insert.
+   * @param update_tree @c true to update the RBTree structure.
    */
-  void insert_before(Node *spot, Node *node, bool updateTree = true);
+  void insert_before(Node *spot, Node *node, bool update_tree = true);
 
   /** Insert @a node after @a spot.
    *
    * @param spot Target node.
    * @param node Node to insert.
+   * @param update_tree @c true to update the RBTree structure.
    */
-  void insert_after(Node *spot, Node *node, bool updateTree = true);
+  void insert_after(Node *spot, Node *node, bool update_tree = true);
 
   /** Add @a node to tree as the first element.
    *
    * @param node Node to prepend.
+   * @param update_tree @c true to update the RBTree structure.
    *
    * Invariant - @a node is first in order.
    */
-  void prepend(Node *node, bool updateTree = true);
+  void prepend(Node *node, bool update_tree = true);
 
   /** Add @a node to tree as the last node.
    *
    * @param node Node to append.
+   * @param update_tree @c true to update the RBTree structure.
    *
    * Invariant - @a node is last in order.
    */
-  void append(Node *node, bool updateTree = true);
+  void append(Node *node, bool update_tree = true);
 
   /** Remove node from container and update container.
    *
    * @param node Node to remove.
+   * @param update_tree @c true to update the RBTree structure.
    */
-  void remove(Node *node, bool updateTree = true);
+  void remove(Node *node, bool update_tree = true);
 };
 
 // ---
@@ -1221,9 +1238,9 @@ DiscreteSpace<METRIC, PAYLOAD>::intersection(DiscreteSpace::range_type const &ra
 
 template <typename METRIC, typename PAYLOAD>
 void
-DiscreteSpace<METRIC, PAYLOAD>::prepend(DiscreteSpace::Node *node, bool updateTree) {
+DiscreteSpace<METRIC, PAYLOAD>::prepend(DiscreteSpace::Node *node, bool update_tree) {
 
-  if (updateTree) {
+  if (update_tree) {
     if (!_root) {
       _root = node;
     } else {
@@ -1236,9 +1253,9 @@ DiscreteSpace<METRIC, PAYLOAD>::prepend(DiscreteSpace::Node *node, bool updateTr
 
 template <typename METRIC, typename PAYLOAD>
 void
-DiscreteSpace<METRIC, PAYLOAD>::append(DiscreteSpace::Node *node, bool updateTree) {
+DiscreteSpace<METRIC, PAYLOAD>::append(DiscreteSpace::Node *node, bool update_tree) {
   
-  if (updateTree) {
+  if (update_tree) {
     if (!_root) {
       _root = node;
     } else {
@@ -1252,10 +1269,10 @@ DiscreteSpace<METRIC, PAYLOAD>::append(DiscreteSpace::Node *node, bool updateTre
 
 template <typename METRIC, typename PAYLOAD>
 void
-DiscreteSpace<METRIC, PAYLOAD>::remove(DiscreteSpace::Node *node, bool updateTree) {
+DiscreteSpace<METRIC, PAYLOAD>::remove(DiscreteSpace::Node *node, bool update_tree) {
   _list.erase(node);
   _fa.destroy(node);
-  if (!updateTree) {
+  if (!update_tree) {
     return;
   }
   _root = static_cast<Node *>(node->remove());
@@ -1263,9 +1280,9 @@ DiscreteSpace<METRIC, PAYLOAD>::remove(DiscreteSpace::Node *node, bool updateTre
 
 template <typename METRIC, typename PAYLOAD>
 void
-DiscreteSpace<METRIC, PAYLOAD>::insert_before(DiscreteSpace::Node *spot, DiscreteSpace::Node *node, bool updateTree) {
+DiscreteSpace<METRIC, PAYLOAD>::insert_before(DiscreteSpace::Node *spot, DiscreteSpace::Node *node, bool update_tree) {
 
-  if (updateTree) {
+  if (update_tree) {
     if (left(spot) == nullptr) {
       spot->set_child(node, Direction::LEFT);
     } else {
@@ -1278,16 +1295,16 @@ DiscreteSpace<METRIC, PAYLOAD>::insert_before(DiscreteSpace::Node *spot, Discret
 
   _list.insert_before(spot, node);
 
-  if (updateTree) {
+  if (update_tree) {
     _root = static_cast<Node *>(node->rebalance_after_insert());
   }
 }
 
 template <typename METRIC, typename PAYLOAD>
 void
-DiscreteSpace<METRIC, PAYLOAD>::insert_after(DiscreteSpace::Node *spot, DiscreteSpace::Node *node, bool updateTree) {
+DiscreteSpace<METRIC, PAYLOAD>::insert_after(DiscreteSpace::Node *spot, DiscreteSpace::Node *node, bool update_tree) {
 
-  if (updateTree) {
+  if (update_tree) {
     if (right(spot) == nullptr) {
       spot->set_child(node, Direction::RIGHT);
     } else {
@@ -1300,7 +1317,7 @@ DiscreteSpace<METRIC, PAYLOAD>::insert_after(DiscreteSpace::Node *spot, Discrete
 
   _list.insert_after(spot, node);
 
-  if (updateTree) {
+  if (update_tree) {
     _root = static_cast<Node *>(node->rebalance_after_insert());
   }
 }
@@ -1337,13 +1354,13 @@ DiscreteSpace<METRIC, PAYLOAD>::erase(DiscreteSpace::range_type const &range) {
 }
 
 template <typename METRIC, typename PAYLOAD>
-void
+DiscreteSpace<METRIC, PAYLOAD> &
 DiscreteSpace<METRIC, PAYLOAD>::mark_bulk(std::vector<std::pair<DiscreteSpace::range_type, PAYLOAD>> const &ranges) {
-  this->mark_bulk(ranges.data(), ranges.size());
+  return this->mark_bulk(ranges.data(), ranges.size());
 }
 
 template <typename METRIC, typename PAYLOAD>
-void
+DiscreteSpace<METRIC, PAYLOAD> &
 DiscreteSpace<METRIC, PAYLOAD>::mark_bulk(std::pair<range_type, PAYLOAD>* start, size_t n)
 {
   // Timer [i_range]: 0.934797 seconds
@@ -1357,11 +1374,13 @@ DiscreteSpace<METRIC, PAYLOAD>::mark_bulk(std::pair<range_type, PAYLOAD>* start,
   // Rebuild the entire red-black tree.
   detail::RBNode* temp_head = _list.head();
   _root = static_cast<Node *>(detail::RBNode::buildTree(temp_head, _list.count()));
+
+  return *this;
 }
 
 template <typename METRIC, typename PAYLOAD>
 DiscreteSpace<METRIC, PAYLOAD> &
-DiscreteSpace<METRIC, PAYLOAD>::mark(DiscreteSpace::range_type const &range, PAYLOAD const &payload, bool updateTree) {
+DiscreteSpace<METRIC, PAYLOAD>::mark(DiscreteSpace::range_type const &range, PAYLOAD const &payload, bool update_tree) {
   Node *n = this->lower_node(range.min()); // current node.
   Node *x = nullptr;                       // New node, gets set if we re-use an existing one.
   Node *y = nullptr;                       // Temporary for removing and advancing.
@@ -1383,7 +1402,7 @@ DiscreteSpace<METRIC, PAYLOAD>::mark(DiscreteSpace::range_type const &range, PAY
       if (p && p->payload() == payload && p->max() == min_minus_1) {
         x = p;
         n = x; // need to back up n because frame of reference moved.
-        x->assign_max(range.max(), updateTree);
+        x->assign_max(range.max(), update_tree);
       } else if (n->max() <= range.max()) {
         // Span will be subsumed by request span so it's available for use.
         x = n;
@@ -1393,8 +1412,8 @@ DiscreteSpace<METRIC, PAYLOAD>::mark(DiscreteSpace::range_type const &range, PAY
       } else {
         // request span is covered by existing span.
         x = _fa.make(range, payload); //
-        n->assign_min(max_plus_1, updateTree);    // clip existing.
-        this->insert_before(n, x, updateTree);
+        n->assign_min(max_plus_1, update_tree);    // clip existing.
+        this->insert_before(n, x, update_tree);
         return *this;
       }
     } else if (n->payload() == payload && n->max() >= min_minus_1) {
@@ -1404,19 +1423,19 @@ DiscreteSpace<METRIC, PAYLOAD>::mark(DiscreteSpace::range_type const &range, PAY
       if (x->max() >= range.max()) {
         return *this;
       }
-      x->assign_max(range.max(), updateTree);
+      x->assign_max(range.max(), update_tree);
     } else if (n->max() <= range.max()) {
       // Can only have left skew overlap, otherwise disjoint.
       // Clip if overlap.
       if (n->max() >= range.min()) {
-        n->assign_max(min_minus_1, updateTree);
+        n->assign_max(min_minus_1, update_tree);
       } else if (nullptr != (y = next(n)) && y->max() <= range.max()) {
         // because @a n was selected as the minimum it must be the case that
         // y->min >= min (or y would have been selected). Therefore in this
         // case the request covers the next node therefore it can be reused.
         x = y;
         x->assign(range).assign(payload);
-        if (updateTree)
+        if (update_tree)
         {
             x->ripple_structure_fixup();
         }
@@ -1429,18 +1448,18 @@ DiscreteSpace<METRIC, PAYLOAD>::mark(DiscreteSpace::range_type const &range, PAY
       Node *r;
       x = _fa.make(range, payload);
       r = _fa.make(range_type{max_plus_1, n->max()}, n->payload());
-      n->assign_max(min_minus_1, updateTree);
-      this->insert_after(n, x, updateTree);
-      this->insert_after(x, r, updateTree);
+      n->assign_max(min_minus_1, update_tree);
+      this->insert_after(n, x, update_tree);
+      this->insert_after(x, r, update_tree);
       return *this; // done.
     }
     n = next(n); // lower bound span handled, move on.
     if (!x) {
       x = _fa.make(range, payload);
       if (n) {
-        this->insert_before(n, x, updateTree);
+        this->insert_before(n, x, update_tree);
       } else {
-        this->append(x, updateTree); // note that since n == 0 we'll just return.
+        this->append(x, update_tree); // note that since n == 0 we'll just return.
       }
     }
   } else if (nullptr != (n = this->head()) &&                    // at least one node in tree.
@@ -1450,13 +1469,13 @@ DiscreteSpace<METRIC, PAYLOAD>::mark(DiscreteSpace::range_type const &range, PAY
     // Same payload with overlap, re-use.
     x = n;
     n = next(n);
-    x->assign_min(range.min(), updateTree);
+    x->assign_min(range.min(), update_tree);
     if (x->max() < range.max()) {
-      x->assign_max(range.max(), updateTree);
+      x->assign_max(range.max(), update_tree);
     }
   } else {
     x = _fa.make(range, payload);
-    this->prepend(x, updateTree);
+    this->prepend(x, update_tree);
   }
 
   // At this point, @a x has the node for this span and all existing spans of
@@ -1465,16 +1484,16 @@ DiscreteSpace<METRIC, PAYLOAD>::mark(DiscreteSpace::range_type const &range, PAY
     if (n->max() <= range.max()) { // completely covered, drop span, continue
       y = n;
       n = next(n);
-      this->remove(y, updateTree);
+      this->remove(y, update_tree);
     } else if (max_plus_1 < n->min()) { // no overlap, done.
       break;
     } else if (n->payload() == payload) { // skew overlap or adj., same payload
-      x->assign_max(n->max(), updateTree);
+      x->assign_max(n->max(), update_tree);
       y = n;
       n = next(n);
-      this->remove(y, updateTree);
+      this->remove(y, update_tree);
     } else if (n->min() <= range.max()) { // skew overlap different payload
-      n->assign_min(max_plus_1, updateTree);
+      n->assign_min(max_plus_1, update_tree);
       break;
     } else { // n->min() > range.max(), different payloads - done.
       break;

--- a/code/include/swoc/DiscreteRange.h
+++ b/code/include/swoc/DiscreteRange.h
@@ -1363,14 +1363,16 @@ template <typename METRIC, typename PAYLOAD>
 DiscreteSpace<METRIC, PAYLOAD> &
 DiscreteSpace<METRIC, PAYLOAD>::mark_bulk(std::pair<range_type, PAYLOAD>* start, size_t n)
 {
-  // Timer [i_range]: 0.934797 seconds
+  // Timer [i_range]: ~1.2 seconds for n=3355591
+  // Loop takes ~0.357612 microseconds in total.
   for (size_t i = 0; i < n; ++i)
   {
     auto const& [range, payload] = start[i];
     this->mark(range, payload, false);
   }
 
-  // Timer [tree]: 0.0280254 seconds
+  // Timer [tree]: ~0.06 seconds for n=3355591
+  // buildTree() takes ~0.017881 microseconds.
   // Rebuild the entire red-black tree.
   detail::RBNode* temp_head = _list.head();
   _root = static_cast<Node *>(detail::RBNode::buildTree(temp_head, _list.count()));

--- a/code/include/swoc/DiscreteRange.h
+++ b/code/include/swoc/DiscreteRange.h
@@ -8,6 +8,7 @@
  */
 
 #pragma once
+#include <algorithm>
 #include <limits>
 #include <functional>
 
@@ -838,19 +839,19 @@ public:
   /** Mark ranges in one operation.
    * 
    * @param marks Vector of ranges and payloads to mark.
-   * @param isSorted @c true if input is sorted, @c false if not. Assumes not sorted.
+   * @param is_sorted @c true if input is sorted, @c false if not. Assumes not sorted.
    * @return @a this
    */
-  self_type &mark_bulk(std::vector<std::pair<range_type, PAYLOAD>> &marks, bool isSorted = false);
+  self_type &mark_bulk(std::vector<std::pair<range_type, PAYLOAD>> &marks, bool is_sorted = false);
 
   /** Mark ranges in one operation.
    * 
    * @param start Pointer to the first range/payload pair.
    * @param n Number of pairs.
-   * @param isSorted @c true if input is sorted, @c false if not. Assumes not sorted.
+   * @param is_sorted @c true if input is sorted, @c false if not. Assumes not sorted.
    * @return @a this
    */
-  self_type &mark_bulk(std::pair<range_type, PAYLOAD>* start, size_t n, bool isSorted = false);
+  self_type &mark_bulk(std::pair<range_type, PAYLOAD>* start, size_t n, bool is_sorted = false);
 
   /** Set the @a payload for a @a range
    *
@@ -1357,16 +1358,16 @@ DiscreteSpace<METRIC, PAYLOAD>::erase(DiscreteSpace::range_type const &range) {
 
 template <typename METRIC, typename PAYLOAD>
 DiscreteSpace<METRIC, PAYLOAD> &
-DiscreteSpace<METRIC, PAYLOAD>::mark_bulk(std::vector<std::pair<DiscreteSpace::range_type, PAYLOAD>> &ranges, bool isSorted) {
-  return this->mark_bulk(ranges.data(), ranges.size(), isSorted);
+DiscreteSpace<METRIC, PAYLOAD>::mark_bulk(std::vector<std::pair<DiscreteSpace::range_type, PAYLOAD>> &ranges, bool is_sorted) {
+  return this->mark_bulk(ranges.data(), ranges.size(), is_sorted);
 }
 
 template <typename METRIC, typename PAYLOAD>
 DiscreteSpace<METRIC, PAYLOAD> &
-DiscreteSpace<METRIC, PAYLOAD>::mark_bulk(std::pair<range_type, PAYLOAD>* start, size_t n, bool isSorted)
+DiscreteSpace<METRIC, PAYLOAD>::mark_bulk(std::pair<range_type, PAYLOAD>* start, size_t n, bool is_sorted)
 {
   // Sort the input data in-place before processing, if applicable.
-  if (!isSorted)
+  if (!is_sorted)
   {
     // Stable sort allows for duplicate elements.
     std::stable_sort(start, start + n, [](const auto &lhs, const auto &rhs) {

--- a/code/include/swoc/IPRange.h
+++ b/code/include/swoc/IPRange.h
@@ -1145,6 +1145,9 @@ public:
    */
   self_type &mark_bulk(std::pair<DiscreteRange<IP4Addr>, PAYLOAD>* range_payloads, size_t size);
 
+  //! vector-based interface for the previous function.
+  self_type &mark_bulk(std::vector<std::pair<DiscreteRange<IP4Addr>, PAYLOAD>>& range_payloads);
+
   /** Mark ranges of IP6Addr in the IPSpace in one operation.
    * 
    * @param range_payloads Array of range/payload pairs.
@@ -1152,6 +1155,9 @@ public:
    * @return @a this
    */
   self_type &mark_bulk(std::pair<DiscreteRange<IP6Addr>, PAYLOAD>* range_payloads, size_t size);
+
+  //! vector-based interface for the previous function.
+  self_type &mark_bulk(std::vector<std::pair<DiscreteRange<IP6Addr>, PAYLOAD>>& range_payloads);
 
   /** Fill the @a range with @a payload.
    *
@@ -2491,6 +2497,20 @@ template <typename PAYLOAD>
 auto
 IPSpace<PAYLOAD>::mark_bulk(std::pair<DiscreteRange<IP6Addr>, PAYLOAD>* range_payloads, size_t size) -> self_type & {
   _ip6.mark_bulk(range_payloads, size);
+  return *this;
+}
+
+template <typename PAYLOAD>
+auto
+IPSpace<PAYLOAD>::mark_bulk(std::vector<std::pair<DiscreteRange<IP4Addr>, PAYLOAD>>& range_payloads) -> self_type & {
+  _ip4.mark_bulk(range_payloads);
+  return *this;
+}
+
+template <typename PAYLOAD>
+auto
+IPSpace<PAYLOAD>::mark_bulk(std::vector<std::pair<DiscreteRange<IP6Addr>, PAYLOAD>>& range_payloads) -> self_type & {
+  _ip6.mark_bulk(range_payloads);
   return *this;
 }
 

--- a/code/include/swoc/IPRange.h
+++ b/code/include/swoc/IPRange.h
@@ -1137,9 +1137,20 @@ public:
    */
   self_type &mark(IPRange const &range, PAYLOAD const &payload);
 
-  // TODO
-  // self_type &mark_bulk(std::pair<IP4Range, PAYLOAD>* range_payloads, size_t size);
+  /** Mark ranges of IP4Addr in the IPSpace in one operation.
+   * 
+   * @param range_payloads Array of range/payload pairs.
+   * @param size Number of elements in @a range_payloads.
+   * @return @a this
+   */
   self_type &mark_bulk(std::pair<DiscreteRange<IP4Addr>, PAYLOAD>* range_payloads, size_t size);
+
+  /** Mark ranges of IP6Addr in the IPSpace in one operation.
+   * 
+   * @param range_payloads Array of range/payload pairs.
+   * @param size Number of elements in @a range_payloads.
+   * @return @a this
+   */
   self_type &mark_bulk(std::pair<DiscreteRange<IP6Addr>, PAYLOAD>* range_payloads, size_t size);
 
   /** Fill the @a range with @a payload.

--- a/code/include/swoc/IPRange.h
+++ b/code/include/swoc/IPRange.h
@@ -1141,25 +1141,25 @@ public:
    * 
    * @param range_payloads Array of range/payload pairs.
    * @param size Number of elements in @a range_payloads.
-   * @param isSorted @c true if input is sorted, @c false if not. Assumes not sorted.
+   * @param is_sorted @c true if input is sorted, @c false if not. Assumes not sorted.
    * @return @a this
    */
-  self_type &mark_bulk(std::pair<DiscreteRange<IP4Addr>, PAYLOAD>* range_payloads, size_t size, bool isSorted = false);
+  self_type &mark_bulk(std::pair<DiscreteRange<IP4Addr>, PAYLOAD>* range_payloads, size_t size, bool is_sorted = false);
 
   //! vector-based interface for the previous function.
-  self_type &mark_bulk(std::vector<std::pair<DiscreteRange<IP4Addr>, PAYLOAD>>& range_payloads, bool isSorted = false);
+  self_type &mark_bulk(std::vector<std::pair<DiscreteRange<IP4Addr>, PAYLOAD>>& range_payloads, bool is_sorted = false);
 
   /** Mark ranges of IP6Addr in the IPSpace in one operation.
    * 
    * @param range_payloads Array of range/payload pairs.
    * @param size Number of elements in @a range_payloads.
-   * @param isSorted @c true if input is sorted, @c false if not. Assumes not sorted.
+   * @param is_sorted @c true if input is sorted, @c false if not. Assumes not sorted.
    * @return @a this
    */
-  self_type &mark_bulk(std::pair<DiscreteRange<IP6Addr>, PAYLOAD>* range_payloads, size_t size, bool isSorted = false);
+  self_type &mark_bulk(std::pair<DiscreteRange<IP6Addr>, PAYLOAD>* range_payloads, size_t size, bool is_sorted = false);
 
   //! vector-based interface for the previous function.
-  self_type &mark_bulk(std::vector<std::pair<DiscreteRange<IP6Addr>, PAYLOAD>>& range_payloads, bool isSorted = false);
+  self_type &mark_bulk(std::vector<std::pair<DiscreteRange<IP6Addr>, PAYLOAD>>& range_payloads, bool is_sorted = false);
 
   /** Fill the @a range with @a payload.
    *
@@ -2490,29 +2490,29 @@ IPRange::NetSource::operator!=(self_type const &that) const {
 
 template <typename PAYLOAD>
 auto
-IPSpace<PAYLOAD>::mark_bulk(std::pair<DiscreteRange<IP4Addr>, PAYLOAD>* range_payloads, size_t size, bool isSorted) -> self_type & {
-  _ip4.mark_bulk(range_payloads, size, isSorted);
+IPSpace<PAYLOAD>::mark_bulk(std::pair<DiscreteRange<IP4Addr>, PAYLOAD>* range_payloads, size_t size, bool is_sorted) -> self_type & {
+  _ip4.mark_bulk(range_payloads, size, is_sorted);
   return *this;
 }
 
 template <typename PAYLOAD>
 auto
-IPSpace<PAYLOAD>::mark_bulk(std::pair<DiscreteRange<IP6Addr>, PAYLOAD>* range_payloads, size_t size, bool isSorted) -> self_type & {
-  _ip6.mark_bulk(range_payloads, size, isSorted);
+IPSpace<PAYLOAD>::mark_bulk(std::pair<DiscreteRange<IP6Addr>, PAYLOAD>* range_payloads, size_t size, bool is_sorted) -> self_type & {
+  _ip6.mark_bulk(range_payloads, size, is_sorted);
   return *this;
 }
 
 template <typename PAYLOAD>
 auto
-IPSpace<PAYLOAD>::mark_bulk(std::vector<std::pair<DiscreteRange<IP4Addr>, PAYLOAD>>& range_payloads, bool isSorted) -> self_type & {
-  _ip4.mark_bulk(range_payloads, isSorted);
+IPSpace<PAYLOAD>::mark_bulk(std::vector<std::pair<DiscreteRange<IP4Addr>, PAYLOAD>>& range_payloads, bool is_sorted) -> self_type & {
+  _ip4.mark_bulk(range_payloads, is_sorted);
   return *this;
 }
 
 template <typename PAYLOAD>
 auto
-IPSpace<PAYLOAD>::mark_bulk(std::vector<std::pair<DiscreteRange<IP6Addr>, PAYLOAD>>& range_payloads, bool isSorted) -> self_type & {
-  _ip6.mark_bulk(range_payloads, isSorted);
+IPSpace<PAYLOAD>::mark_bulk(std::vector<std::pair<DiscreteRange<IP6Addr>, PAYLOAD>>& range_payloads, bool is_sorted) -> self_type & {
+  _ip6.mark_bulk(range_payloads, is_sorted);
   return *this;
 }
 

--- a/code/include/swoc/IPRange.h
+++ b/code/include/swoc/IPRange.h
@@ -2505,14 +2505,14 @@ IPSpace<PAYLOAD>::mark_bulk(std::pair<DiscreteRange<IP6Addr>, PAYLOAD>* range_pa
 template <typename PAYLOAD>
 auto
 IPSpace<PAYLOAD>::mark_bulk(std::vector<std::pair<DiscreteRange<IP4Addr>, PAYLOAD>>& range_payloads, bool isSorted) -> self_type & {
-  _ip4.mark_bulk(range_payloads);
+  _ip4.mark_bulk(range_payloads, isSorted);
   return *this;
 }
 
 template <typename PAYLOAD>
 auto
 IPSpace<PAYLOAD>::mark_bulk(std::vector<std::pair<DiscreteRange<IP6Addr>, PAYLOAD>>& range_payloads, bool isSorted) -> self_type & {
-  _ip6.mark_bulk(range_payloads);
+  _ip6.mark_bulk(range_payloads, isSorted);
   return *this;
 }
 

--- a/code/include/swoc/IPRange.h
+++ b/code/include/swoc/IPRange.h
@@ -1137,6 +1137,11 @@ public:
    */
   self_type &mark(IPRange const &range, PAYLOAD const &payload);
 
+  // TODO
+  // self_type &mark_bulk(std::pair<IP4Range, PAYLOAD>* range_payloads, size_t size);
+  self_type &mark_bulk(std::pair<DiscreteRange<IP4Addr>, PAYLOAD>* range_payloads, size_t size);
+  self_type &mark_bulk(std::pair<DiscreteRange<IP6Addr>, PAYLOAD>* range_payloads, size_t size);
+
   /** Fill the @a range with @a payload.
    *
    * @param range Destination range.
@@ -2463,6 +2468,20 @@ IPRange::NetSource::operator!=(self_type const &that) const {
 }
 
 // --- IPSpace
+
+template <typename PAYLOAD>
+auto
+IPSpace<PAYLOAD>::mark_bulk(std::pair<DiscreteRange<IP4Addr>, PAYLOAD>* range_payloads, size_t size) -> self_type & {
+  _ip4.mark_bulk(range_payloads, size);
+  return *this;
+}
+
+template <typename PAYLOAD>
+auto
+IPSpace<PAYLOAD>::mark_bulk(std::pair<DiscreteRange<IP6Addr>, PAYLOAD>* range_payloads, size_t size) -> self_type & {
+  _ip6.mark_bulk(range_payloads, size);
+  return *this;
+}
 
 template <typename PAYLOAD>
 auto

--- a/code/include/swoc/IPRange.h
+++ b/code/include/swoc/IPRange.h
@@ -1141,23 +1141,25 @@ public:
    * 
    * @param range_payloads Array of range/payload pairs.
    * @param size Number of elements in @a range_payloads.
+   * @param isSorted @c true if input is sorted, @c false if not. Assumes not sorted.
    * @return @a this
    */
-  self_type &mark_bulk(std::pair<DiscreteRange<IP4Addr>, PAYLOAD>* range_payloads, size_t size);
+  self_type &mark_bulk(std::pair<DiscreteRange<IP4Addr>, PAYLOAD>* range_payloads, size_t size, bool isSorted = false);
 
   //! vector-based interface for the previous function.
-  self_type &mark_bulk(std::vector<std::pair<DiscreteRange<IP4Addr>, PAYLOAD>>& range_payloads);
+  self_type &mark_bulk(std::vector<std::pair<DiscreteRange<IP4Addr>, PAYLOAD>>& range_payloads, bool isSorted = false);
 
   /** Mark ranges of IP6Addr in the IPSpace in one operation.
    * 
    * @param range_payloads Array of range/payload pairs.
    * @param size Number of elements in @a range_payloads.
+   * @param isSorted @c true if input is sorted, @c false if not. Assumes not sorted.
    * @return @a this
    */
-  self_type &mark_bulk(std::pair<DiscreteRange<IP6Addr>, PAYLOAD>* range_payloads, size_t size);
+  self_type &mark_bulk(std::pair<DiscreteRange<IP6Addr>, PAYLOAD>* range_payloads, size_t size, bool isSorted = false);
 
   //! vector-based interface for the previous function.
-  self_type &mark_bulk(std::vector<std::pair<DiscreteRange<IP6Addr>, PAYLOAD>>& range_payloads);
+  self_type &mark_bulk(std::vector<std::pair<DiscreteRange<IP6Addr>, PAYLOAD>>& range_payloads, bool isSorted = false);
 
   /** Fill the @a range with @a payload.
    *
@@ -2488,28 +2490,28 @@ IPRange::NetSource::operator!=(self_type const &that) const {
 
 template <typename PAYLOAD>
 auto
-IPSpace<PAYLOAD>::mark_bulk(std::pair<DiscreteRange<IP4Addr>, PAYLOAD>* range_payloads, size_t size) -> self_type & {
-  _ip4.mark_bulk(range_payloads, size);
+IPSpace<PAYLOAD>::mark_bulk(std::pair<DiscreteRange<IP4Addr>, PAYLOAD>* range_payloads, size_t size, bool isSorted) -> self_type & {
+  _ip4.mark_bulk(range_payloads, size, isSorted);
   return *this;
 }
 
 template <typename PAYLOAD>
 auto
-IPSpace<PAYLOAD>::mark_bulk(std::pair<DiscreteRange<IP6Addr>, PAYLOAD>* range_payloads, size_t size) -> self_type & {
-  _ip6.mark_bulk(range_payloads, size);
+IPSpace<PAYLOAD>::mark_bulk(std::pair<DiscreteRange<IP6Addr>, PAYLOAD>* range_payloads, size_t size, bool isSorted) -> self_type & {
+  _ip6.mark_bulk(range_payloads, size, isSorted);
   return *this;
 }
 
 template <typename PAYLOAD>
 auto
-IPSpace<PAYLOAD>::mark_bulk(std::vector<std::pair<DiscreteRange<IP4Addr>, PAYLOAD>>& range_payloads) -> self_type & {
+IPSpace<PAYLOAD>::mark_bulk(std::vector<std::pair<DiscreteRange<IP4Addr>, PAYLOAD>>& range_payloads, bool isSorted) -> self_type & {
   _ip4.mark_bulk(range_payloads);
   return *this;
 }
 
 template <typename PAYLOAD>
 auto
-IPSpace<PAYLOAD>::mark_bulk(std::vector<std::pair<DiscreteRange<IP6Addr>, PAYLOAD>>& range_payloads) -> self_type & {
+IPSpace<PAYLOAD>::mark_bulk(std::vector<std::pair<DiscreteRange<IP6Addr>, PAYLOAD>>& range_payloads, bool isSorted) -> self_type & {
   _ip6.mark_bulk(range_payloads);
   return *this;
 }

--- a/code/include/swoc/RBTree.h
+++ b/code/include/swoc/RBTree.h
@@ -186,13 +186,20 @@ struct RBNode {
    * 
    * @param head         Copy of the head pointer of the list.
    * @param n            Number of nodes being processed at the current level.
-   * @param isBlack      Default is true (root node is always black).
    * @return self_type*  The root node of the tree.
    */
   static self_type * buildTree(self_type*& head, int n);
 
+  //! Called by buildTree above.
   static self_type * buildTree(self_type*& head, int n, bool isBlack);
 
+  /**
+   * @brief Recursively print the tree in a human-readable format.
+   *
+   * @param root   Root node of the tree.
+   * @param indent Indentation string.
+   * @param last   Flag to indicate if the node is the last node.
+   */
   static void printTree(self_type* root, std::string indent = "", bool last = true);
 
   Color _color{Color::RED};    ///< node color

--- a/code/include/swoc/RBTree.h
+++ b/code/include/swoc/RBTree.h
@@ -7,10 +7,10 @@
 
 #pragma once
 
-#include <iostream>
-
 #include "swoc/swoc_version.h"
 #include "swoc/IntrusiveDList.h"
+
+#include <string>
 
 namespace swoc { inline namespace SWOC_VERSION_NS { namespace detail {
 /** A node in a red/black tree.

--- a/code/include/swoc/RBTree.h
+++ b/code/include/swoc/RBTree.h
@@ -6,6 +6,9 @@
 */
 
 #pragma once
+
+#include <iostream>
+
 #include "swoc/swoc_version.h"
 #include "swoc/IntrusiveDList.h"
 
@@ -174,6 +177,24 @@ struct RBNode {
    */
   self_type *ripple_structure_fixup();
 
+  /**
+   * @brief  Recursively build a balanced RB tree from a sorted linked list.
+   * 
+   * Constraints:
+   *  - The list is sorted in ascending order.
+   *  - A copy (not reference) of the head pointer is passed in.
+   * 
+   * @param head         Copy of the head pointer of the list.
+   * @param n            Number of nodes being processed at the current level.
+   * @param isBlack      Default is true (root node is always black).
+   * @return self_type*  The root node of the tree.
+   */
+  static self_type * buildTree(self_type*& head, int n);
+
+  static self_type * buildTree(self_type*& head, int n, bool isBlack);
+
+  static void printTree(self_type* root, std::string indent = "", bool last = true);
+
   Color _color{Color::RED};    ///< node color
   self_type *_parent{nullptr}; ///< parent node (needed for rotations)
   self_type *_left{nullptr};   ///< left child
@@ -188,7 +209,7 @@ struct RBNode {
     next_ptr(self_type *t) {
       return swoc::ptr_ref_cast<self_type>(t->_next);
     }
-    /// @return Reference to the internal pointer to the previoius element.
+    /// @return Reference to the internal pointer to the previous element.
     static self_type *&
     prev_ptr(self_type *t) {
       return swoc::ptr_ref_cast<self_type>(t->_prev);

--- a/code/src/RBTree.cc
+++ b/code/src/RBTree.cc
@@ -7,6 +7,8 @@
 
 #include "swoc/RBTree.h"
 
+#include <iostream>
+
 namespace swoc { inline namespace SWOC_VERSION_NS { namespace detail {
 // These equality operators are only used in this file.
 

--- a/code/src/RBTree.cc
+++ b/code/src/RBTree.cc
@@ -308,8 +308,6 @@ RBNode::buildTree(RBNode*& head, int n)
   return root;
 }
 
-// This might produce a red node with single b child, I need to test.
-// Recursive function to build a balanced BST from a sorted doubly linked list.
 RBNode *
 RBNode::buildTree(RBNode*& head, int n, bool isBlack)
 {
@@ -345,8 +343,6 @@ RBNode::buildTree(RBNode*& head, int n, bool isBlack)
     if (n != 2)
     {
       // Recursively construct the right subtree.
-      // n - half_n - 1 is the number of nodes remaining from
-      // the left subtree and the current node.
       currNode->_right = buildTree(head, right_n, leftBranch->_color == Color::BLACK);
     }
     // If you have an n == 2 case, there is only a left child and it must be red.
@@ -365,7 +361,6 @@ RBNode::buildTree(RBNode*& head, int n, bool isBlack)
     return currNode;
 }
 
-//
 void
 RBNode::printTree(RBNode* root, std::string indent, bool last)
 {

--- a/code/src/RBTree.cc
+++ b/code/src/RBTree.cc
@@ -293,6 +293,102 @@ RBNode::rebalance_after_remove(Color c,    //!< The color of the removed node
   return root;
 }
 
+RBNode * 
+RBNode::buildTree(RBNode*& head, int n)
+{
+  if (!head || n <= 0)
+  {
+    return head;
+  }
+  RBNode* root = buildTree(head, n, true);
+
+  // The root node is always black.
+  root->_color = Color::BLACK;
+
+  return root;
+}
+
+// This might produce a red node with single b child, I need to test.
+// Recursive function to build a balanced BST from a sorted doubly linked list.
+RBNode *
+RBNode::buildTree(RBNode*& head, int n, bool isBlack)
+{
+    if (n <= 1)
+    {
+      RBNode* currNode = head;
+      currNode->_color = isBlack ? Color::BLACK : Color::RED;
+      head = head->_next;
+      return currNode;
+    }
+  
+    // Always handle the even number of nodes first because it is guaranteed to contain an n == 2 case.
+    int left_n = n / 2;
+    int right_n = n - left_n - 1;
+    if (right_n % 2 == 0)
+    {
+        std::swap(left_n, right_n);
+    }
+  
+    // Recursively construct the left subtree.
+    RBNode* leftBranch = buildTree(head, left_n, !isBlack);
+  
+    // Assign the left branch to the current node (head).
+    RBNode* currNode = head;
+    currNode->_left = leftBranch;
+  
+    // This can be nullptr if we are at the end.
+    head = head->_next;
+  
+    // If this is currently processing 2 nodes, then don't make a right branch
+    // because the left branch has already been made.
+    // No need to check for head == nullptr here because n > 3 inside the block.
+    if (n != 2)
+    {
+      // Recursively construct the right subtree.
+      // n - half_n - 1 is the number of nodes remaining from
+      // the left subtree and the current node.
+      currNode->_right = buildTree(head, right_n, leftBranch->_color == Color::BLACK);
+    }
+    // If you have an n == 2 case, there is only a left child and it must be red.
+    else
+    {
+      currNode->_left->_color = Color::RED;
+      currNode->_color = Color::BLACK;
+    }
+
+    // If either child is red, then the current node must be black.
+    if (currNode->_left->_color == Color::RED || currNode->_right->_color == Color::RED)
+    {
+      currNode->_color = Color::BLACK;
+    }
+
+    return currNode;
+}
+
+//
+void
+RBNode::printTree(RBNode* root, std::string indent, bool last)
+{
+    if (root == nullptr) {
+        return;
+    }
+    std::cout << indent;
+    if (last) {
+        std::cout << "└─";
+        indent += "  ";
+    } else {
+        std::cout << "├─";
+        indent += "| ";
+    }
+
+    std::string color = (root->_color == Color::RED) ? "R" : "B";
+    std::cout << color << std::endl;
+
+    last = root->_right == nullptr;
+    printTree(root->_left, indent, last);
+    printTree(root->_right, indent, true);
+}
+
 /** Ensure that the local information associated with each node is
     correct globally This should only be called on debug builds as it
     breaks any efficiencies we have gained from our tree structure.
@@ -329,7 +425,7 @@ RBNode::validate() {
   } else {
     std::cout << "Height mismatch " << black_ht1 << " " << black_ht2 << "\n";
   }
-  if (black_ht > 0 && !this->structureValidate())
+  if (black_ht > 0 && !this->structure_validate())
     black_ht = 0;
 
   return black_ht;

--- a/code/src/RBTree.cc
+++ b/code/src/RBTree.cc
@@ -339,7 +339,7 @@ RBNode::buildTree(RBNode*& head, int n, bool isBlack)
   
     // If this is currently processing 2 nodes, then don't make a right branch
     // because the left branch has already been made.
-    // No need to check for head == nullptr here because n > 3 inside the block.
+    // No need to check for head == nullptr here because n > 2 inside the block.
     if (n != 2)
     {
       // Recursively construct the right subtree.
@@ -390,7 +390,7 @@ RBNode::printTree(RBNode* root, std::string indent, bool last)
     */
 int
 RBNode::validate() {
-#if 0
+#if BUILD_TESTING
   int black_ht = 0;
   int black_ht1, black_ht2;
 

--- a/code/src/RBTree.cc
+++ b/code/src/RBTree.cc
@@ -316,6 +316,7 @@ RBNode::buildTree(RBNode*& head, int n, bool isBlack)
       RBNode* currNode = head;
       currNode->_color = isBlack ? Color::BLACK : Color::RED;
       head = head->_next;
+      currNode->structure_fixup();
       return currNode;
     }
   
@@ -357,6 +358,9 @@ RBNode::buildTree(RBNode*& head, int n, bool isBlack)
     {
       currNode->_color = Color::BLACK;
     }
+
+    // structure_fixup() needs to be called from the leaf nodes upward.
+    currNode->structure_fixup();
 
     return currNode;
 }

--- a/doc/code/ip_networking.en.rst
+++ b/doc/code/ip_networking.en.rst
@@ -194,6 +194,12 @@ mark
    payload present. This is modeled on the "painter's algorithm" where the most recent coloring
    replaces any prior colors in the region.
 
+mark_bulk
+   :libswoc:`swoc::IPSpace::mark_bulk` applies multiple :arg:`payload` to the range using the same
+   logic as :code:`mark`. This has much better performance than calling :code:`mark` many times in
+   succession, and results in a much more balanced RBTree structure (for faster lookups) in the case
+   where ip ranges are inserted in ascending order.
+
 fill
    :libswoc:`swoc::IPSpace::fill` applies the :arg:`payload` to the range but only where there is not
    already a payload. This is modeled on "backfilling" a background. This is useful for "first match"

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -41,3 +41,8 @@ if (CMAKE_COMPILER_IS_GNUCXX)
 endif()
 
 add_test(NAME test_libswoc COMMAND test_libswoc)
+
+# Copy files required by tests into the cmake build folder
+file(COPY ${CMAKE_SOURCE_DIR}/doc/conf.py DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/doc)
+file(COPY ${CMAKE_SOURCE_DIR}/unit_tests/examples/resolver.txt DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/unit_tests/examples)
+file(COPY ${CMAKE_SOURCE_DIR}/unit_tests/test_swoc_file.cc DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/unit_tests)

--- a/unit_tests/test_Lexicon.cc
+++ b/unit_tests/test_Lexicon.cc
@@ -19,11 +19,15 @@ using ExampleNames = swoc::Lexicon<Example>;
 
 namespace {
 
+// This section won't compile for GNU 13.
+#if __GNUC__ != 13
+
 // C++20: This compiles because one of the lists has more than 2 elements.
 // I think it's a g++ bug - it compiles in clang. The @c TextView constructor being used
 // is marked @c explicit and so it should be discarded. If the constructor is used explicitly
 // then it doesn't compile as intended. Therefore g++ is accepting a constructor that doesn't work.
 // doc.cpp.20.bravo.start
+
 [[maybe_unused]] ExampleNames Static_Names_Basic{
   {{Example::Value_0, {"zero", "0", "none"}},
    {Example::Value_1, {"one", "1"}},
@@ -43,6 +47,8 @@ namespace {
    {Example::INVALID, {"INVALID"}}}
 };
 // doc.cpp.20.alpha.end
+
+#endif
 
 // If the type isn't easily accessible.
 [[maybe_unused]] ExampleNames Static_Names_Decl{

--- a/unit_tests/test_ip.cc
+++ b/unit_tests/test_ip.cc
@@ -2212,8 +2212,8 @@ TEST_CASE("IPSpace mark_bulk", "[libswoc][ipspace][mark_bulk]") {
     }
 
     // Verify successful mark_bulk
-    space.mark_bulk(addrs4.data(), addrs4.size());
-    space.mark_bulk(addrs6.data(), addrs6.size());
+    space.mark_bulk(addrs4.data(), addrs4.size(), true);
+    space.mark_bulk(addrs6.data(), addrs6.size(), true);
 
     // Verify that the count is correct
     REQUIRE(space.count() == (addrs4.size() + addrs6.size()) / 2);
@@ -2249,8 +2249,8 @@ TEST_CASE("IPSpace mark_bulk", "[libswoc][ipspace][mark_bulk]") {
                         currPayload++);
 
     // Verify successful mark_bulk
-    space.mark_bulk(addrs4.data(), addrs4.size());
-    space.mark_bulk(addrs6.data(), addrs6.size());
+    space.mark_bulk(addrs4, true);
+    space.mark_bulk(addrs6, true);
 
     // Verify that the payloads are correct
     for (auto const& [range, payload] : addrs4) {
@@ -2280,8 +2280,8 @@ TEST_CASE("IPSpace mark_bulk", "[libswoc][ipspace][mark_bulk]") {
             IP6Addr{"::1:20"}},
     currPayload++);
 
-    space.mark_bulk(insert4.data(), insert4.size());
-    space.mark_bulk(insert6.data(), insert6.size());
+    space.mark_bulk(insert4.data(), insert4.size(), true);
+    space.mark_bulk(insert6, true);
 
     // Verify that the ranges were split up.
     {

--- a/unit_tests/test_ip.cc
+++ b/unit_tests/test_ip.cc
@@ -2431,8 +2431,6 @@ TEST_CASE("IPSpace mark_bulk randomized", "[libswoc][ipspace][mark_bulk][randomi
         REQUIRE(p == payload);
     }
 
-    
-
     // Create another ip range before the previous two
     std::vector<std::pair<swoc::DiscreteRange<IP4Addr>, PAYLOAD>> addrs4_3;
     std::vector<std::pair<swoc::DiscreteRange<IP6Addr>, PAYLOAD>> addrs6_3;

--- a/unit_tests/test_ip.cc
+++ b/unit_tests/test_ip.cc
@@ -2212,7 +2212,7 @@ TEST_CASE("IPSpace mark_bulk", "[libswoc][ipspace][mark_bulk]") {
     }
 
     // Verify successful mark_bulk
-    space.mark_bulk(addrs4.data(), addrs4.size(), true);
+    space.mark_bulk(addrs4.data(), addrs4.size(), false);
     space.mark_bulk(addrs6.data(), addrs6.size(), true);
 
     // Verify that the count is correct
@@ -2250,7 +2250,7 @@ TEST_CASE("IPSpace mark_bulk", "[libswoc][ipspace][mark_bulk]") {
 
     // Verify successful mark_bulk
     space.mark_bulk(addrs4, true);
-    space.mark_bulk(addrs6, true);
+    space.mark_bulk(addrs6, false);
 
     // Verify that the payloads are correct
     for (auto const& [range, payload] : addrs4) {
@@ -2327,4 +2327,107 @@ TEST_CASE("IPSpace mark_bulk", "[libswoc][ipspace][mark_bulk]") {
         REQUIRE(p == payload);
     }
 
+}
+
+TEST_CASE("IPSpace mark_bulk randomized", "[libswoc][ipspace][mark_bulk][randomized]") {
+    using PAYLOAD = unsigned;
+    using Space   = swoc::IPSpace<PAYLOAD>;
+
+    Space space;
+
+    // #1 mark_bulk() onto an empty space
+    // Verify that it collapses ranges with the same payload
+    // Use (currPayload++) / 2 as the payload value in order to collapse every-other ip range.
+
+    unsigned currPayload = 0;
+    std::vector<std::pair<swoc::DiscreteRange<IP4Addr>, PAYLOAD>> addrs4;
+    std::vector<std::pair<swoc::DiscreteRange<IP6Addr>, PAYLOAD>> addrs6;
+
+    // 1.1.1.1 - 1.1.1.254, each range is length 1
+    for (int i = 1; i < 128; i += 2) {
+        addrs4.emplace_back(swoc::DiscreteRange<IP4Addr>{IP4Addr{"1.1.1." + std::to_string(i)},
+                                                         IP4Addr{"1.1.1." + std::to_string(i + 1)}},
+                            (currPayload++) / 2);
+    }
+
+    // ::1 - ::254, each range is length 1
+    for (int i = 1; i < 128; i += 2) {
+        addrs6.emplace_back(swoc::DiscreteRange<IP6Addr>{IP6Addr{"::" + std::to_string(i)},
+                                                         IP6Addr{"::" + std::to_string(i + 1)}},
+                            (currPayload++) / 2);
+    }
+
+    // Shuffle both vectors
+    std::random_device rd;
+    std::mt19937 rng(rd());
+    std::shuffle(addrs4.begin(), addrs4.end(), rng);
+    std::shuffle(addrs6.begin(), addrs6.end(), rng);
+
+    // Verify successful mark_bulk
+    space.mark_bulk(addrs4.data(), addrs4.size());
+    space.mark_bulk(addrs6.data(), addrs6.size());
+
+    // Verify that the count is correct
+    size_t size1 = (addrs4.size() + addrs6.size()) / 2;
+    REQUIRE(space.count() == size1);
+    
+    // Verify that the payloads are correct
+    for (auto const& [range, payload] : addrs4) {
+        IP4Addr ip4 = range.min();
+        auto [r, p] = *(space.find(ip4));
+        REQUIRE(r.contains(ip4));
+        REQUIRE(p == payload);
+    }
+
+    for (auto const& [range, payload] : addrs6) {
+        IP6Addr ip6 = range.min();
+        auto [r, p] = *(space.find(ip6));
+        REQUIRE(r.contains(ip6));
+        REQUIRE(p == payload);
+    }
+
+    // Create another ip range after the previous
+    std::vector<std::pair<swoc::DiscreteRange<IP4Addr>, PAYLOAD>> addrs4_2;
+    std::vector<std::pair<swoc::DiscreteRange<IP6Addr>, PAYLOAD>> addrs6_2;
+
+    // 1.1.2.1 - 1.1.2.254, each range is length 1
+    for (int i = 1; i < 128; i += 2) {
+        addrs4_2.emplace_back(swoc::DiscreteRange<IP4Addr>{IP4Addr{"1.1.2." + std::to_string(i)},
+                                                           IP4Addr{"1.1.2." + std::to_string(i + 1)}},
+                              (currPayload++));
+    }
+
+    // :1:1 - :1:254, each range is length 1
+    for (int i = 1; i < 128; i += 2) {
+        addrs6_2.emplace_back(swoc::DiscreteRange<IP6Addr>{IP6Addr{"::1:" + std::to_string(i)},
+                                                           IP6Addr{"::1:" + std::to_string(i + 1)}},
+                              (currPayload++));
+    }
+
+    // shuffle both
+    std::shuffle(addrs4_2.begin(), addrs4_2.end(), rng);
+    std::shuffle(addrs6_2.begin(), addrs6_2.end(), rng);
+
+    // Verify successful mark_bulk
+    space.mark_bulk(addrs4_2);
+    space.mark_bulk(addrs6_2);
+
+    // Verify that the count is correct
+    size_t size2 = addrs4_2.size() + addrs6_2.size();
+    REQUIRE(space.count() == size1 + size2);
+
+    // Verify that the payloads are correct
+    for (auto const& [range, payload] : addrs4_2) {
+        IP4Addr ip4 = range.min();
+        auto [r, p] = *(space.find(ip4));
+        REQUIRE(r.contains(ip4));
+        REQUIRE(p == payload);
+    }
+
+    for (auto const& [range, payload] : addrs6_2) {
+        IP6Addr ip6 = range.min();
+        auto [r, p] = *(space.find(ip6));
+        REQUIRE(r.contains(ip6));
+        REQUIRE(p == payload);
+    }
 }


### PR DESCRIPTION
Improves performance when many ip ranges need to be added to IPSpace at once.

Also results in a better-balanced RB tree whenever many append operations happen in succession.
