### PR TITLE
CMake: Make the code subproject self-contained for FetchContent

### DIFF
--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -6,6 +6,7 @@ set(CMAKE_CXX_STANDARD 17)
 cmake_policy(SET CMP0087 NEW)
 # override "lib64" to be "lib" unless the user explicitly sets it.
 set(CMAKE_INSTALL_LIBDIR "lib" CACHE STRING "directory for libraries" FORCE)
+include(CMakeDependentOption)
 include(GNUInstallDirs)
 
 cmake_dependent_option(LIBSWOC_INSTALL


### PR DESCRIPTION
`code/CMakeLists.txt` uses `cmake_dependent_option`, but it did not load the `CMakeDependentOption` module itself. That works when the top- level project includes the module first, but it breaks consumers that pull `code/` in directly with `FetchContent` and `SOURCE_SUBDIR`.

Include `CMakeDependentOption` in the subproject so the standalone subdirectory build works in both direct and embedded CMake builds.